### PR TITLE
Pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3.10
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    - id: trailing-whitespace
+    - id: check-added-large-files
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.961
+    hooks:
+      - id: mypy

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `examples` directory contains already an example of how
 the parser can be used. We reproduce a part of it here.
 Parsing an EXFOR master file can be done by
 ```
-from exfor_parserpy import ExforBaseParser 
+from exfor_parserpy import ExforBaseParser
 parser = ExforBaseParser()
 exfor_dic = parser.readfile('testdata/entry_21308.txt')
 ```
@@ -80,13 +80,13 @@ However, in each line blanks at the end of the strings are stripped away.
 
 Here is a tree representing the structure of the nested dictionary:
 ```
-21308 -> 21308001 -> BIB -----> AUTHOR (string) 
+21308 -> 21308001 -> BIB -----> AUTHOR (string)
              |      |
              |      L----> REFERENCE (string)
              |      |
              |      L----> REACTION (string)
              |      |
-             |      L----> ...                   
+             |      L----> ...
              |
              |
              L> COMMON --> UNIT ---> ERR-S (string)
@@ -99,7 +99,7 @@ Here is a tree representing the structure of the nested dictionary:
              |                  |
              |                  L--> DATA (float)
              |                  |
-             |                  L--> ...              
+             |                  L--> ...
              |
              L> DATA ----> UNIT ---> ERR-S (string)
                        |        |
@@ -118,15 +118,15 @@ If there are pointers present, e.g., in the `REACTION` field,
 we get for that specific field the following structure
 (assuming there are two pointers named `1` and `A`):
 ```
-O2098 ->O2098002  -> BIB -----> AUTHOR (string)  -> ... 
+O2098 ->O2098002  -> BIB -----> AUTHOR (string)  -> ...
                      |
                      L----> REFERENCE (string)
                      |
-                     L----> REACTION ---> 1 (string) 
+                     L----> REACTION ---> 1 (string)
                      |               |
                      |               L--> A (string)
                      |
-                     L----> ...                   
+                     L----> ...
 ```
 
 The parser was designed to enable the conversion back from a nested
@@ -142,7 +142,7 @@ as much as possible in order to allow for concise code to
 convert back to the EXFOR master file.
 
 The guiding principle during the conception of this parser
-was to keep the basic parser simple and introduce 
+was to keep the basic parser simple and introduce
 transformations to make EXFOR more machine readable
 on the parsed output.
 

--- a/examples/example-001-basic-read-write.py
+++ b/examples/example-001-basic-read-write.py
@@ -7,54 +7,53 @@ TEST_DATA = Path(__file__).resolve().parents[1] / "tests" / "testdata"
 # reading and writing an EXFOR entry
 # with pointers
 parser = ExforBaseParser()
-exfor_entry = parser.readfile(TEST_DATA / 'entry_21308.txt')
-parser.writefile('entry_21308_reproduced.txt', exfor_entry, overwrite=True)
+exfor_entry = parser.readfile(TEST_DATA / "entry_21308.txt")
+parser.writefile("entry_21308_reproduced.txt", exfor_entry, overwrite=True)
 
 # transform the units present in the EXFOR entry
 # all energies to MeV and all cross sections to MB
 # also compound quantities are transformed
 transformed_entry = unitfy(exfor_entry)
-parser.writefile('entry_21308_transformed.txt', transformed_entry, overwrite=True)
+parser.writefile("entry_21308_transformed.txt", transformed_entry, overwrite=True)
 
 # reading and writing an EXFOR entry
 # with COMMON field spanning multiple columns
 parser = ExforBaseParser()
-exfor_entry = parser.readfile(TEST_DATA / 'entry_O2098.txt')
-parser.writefile('entry_O2098_reproduced.txt', exfor_entry, overwrite=True)
+exfor_entry = parser.readfile(TEST_DATA / "entry_O2098.txt")
+parser.writefile("entry_O2098_reproduced.txt", exfor_entry, overwrite=True)
 transformed_entry = unitfy(exfor_entry)
-parser.writefile('entry_O2098_transformed.txt', transformed_entry, overwrite=True)
+parser.writefile("entry_O2098_transformed.txt", transformed_entry, overwrite=True)
 
 # reading an EXFOR entry, modifying some information
 # and writing it back to a file
 parser = ExforBaseParser()
-exfor_entry = parser.readfile(TEST_DATA / 'entry_O2098.txt')
-exfor_entry['O2098']['O2098001']['BIB']['AUTHOR'] = 'Some illegal EXFOR here'
-parser.writefile('entry_O2098_modified.txt', exfor_entry, overwrite=True)
+exfor_entry = parser.readfile(TEST_DATA / "entry_O2098.txt")
+exfor_entry["O2098"]["O2098001"]["BIB"]["AUTHOR"] = "Some illegal EXFOR here"
+parser.writefile("entry_O2098_modified.txt", exfor_entry, overwrite=True)
 
 # test the uncommonfy transformer with a common field
 # in the first subentry
 parser = ExforBaseParser()
-exfor_entry = parser.readfile(TEST_DATA / 'entry_21308.txt')
+exfor_entry = parser.readfile(TEST_DATA / "entry_21308.txt")
 transformed_entry = uncommonfy(exfor_entry)
-exfor_entry['21308']['21308002']['DATA']['UNIT']
-transformed_entry['21308']['21308002']['DATA']['UNIT']
-exfor_entry['21308']['21308002']['DATA']['DATA']
-transformed_entry['21308']['21308002']['DATA']['DATA']
+exfor_entry["21308"]["21308002"]["DATA"]["UNIT"]
+transformed_entry["21308"]["21308002"]["DATA"]["UNIT"]
+exfor_entry["21308"]["21308002"]["DATA"]["DATA"]
+transformed_entry["21308"]["21308002"]["DATA"]["DATA"]
 
 # test the uncommonfy transformer with a common field
 # in the subentry with the data
 parser = ExforBaseParser()
-exfor_entry = parser.readfile(TEST_DATA / 'entry_O2098.txt')
+exfor_entry = parser.readfile(TEST_DATA / "entry_O2098.txt")
 transformed_entry = uncommonfy(exfor_entry)
-exfor_entry['O2098']['O2098002']['DATA']['UNIT']
-transformed_entry['O2098']['O2098002']['DATA']['UNIT']
-exfor_entry['O2098']['O2098002']['DATA']['DATA']
-transformed_entry['O2098']['O2098002']['DATA']['DATA']
+exfor_entry["O2098"]["O2098002"]["DATA"]["UNIT"]
+transformed_entry["O2098"]["O2098002"]["DATA"]["UNIT"]
+exfor_entry["O2098"]["O2098002"]["DATA"]["DATA"]
+transformed_entry["O2098"]["O2098002"]["DATA"]["DATA"]
 
 # test the depointerfy transformer to split up
 # subentries with pointers present
 parser = ExforBaseParser()
-exfor_entry = parser.readfile(TEST_DATA / 'entry_21308.txt')
+exfor_entry = parser.readfile(TEST_DATA / "entry_21308.txt")
 transformed_entry = depointerfy(exfor_entry)
-parser.writefile('entry_21308_depointered.txt', transformed_entry, overwrite=True)
-
+parser.writefile("entry_21308_depointered.txt", transformed_entry, overwrite=True)

--- a/examples/example-002-transformer-demo.py
+++ b/examples/example-002-transformer-demo.py
@@ -1,45 +1,43 @@
 from pathlib import Path
 from exfor_parserpy import ExforBaseParser
-from exfor_parserpy.trafos import (unitfy, uncommonfy,
-        depointerfy, detextify)
+from exfor_parserpy.trafos import unitfy, uncommonfy, depointerfy, detextify
 import json
 
 TEST_DATA = Path(__file__).resolve().parents[1] / "tests" / "testdata"
 
 parser = ExforBaseParser()
-exfor_entry = parser.readfile(TEST_DATA / 'entry_21308.txt')
+exfor_entry = parser.readfile(TEST_DATA / "entry_21308.txt")
 
 # apply all transformations: unitfy, uncommonfy, depointerfy
 trafo_entry = unitfy(exfor_entry)
 trafo_entry = uncommonfy(trafo_entry)
 trafo_entry = depointerfy(trafo_entry)
-parser.writefile('entry_21308_transformed1.txt', trafo_entry, overwrite=True)
+parser.writefile("entry_21308_transformed1.txt", trafo_entry, overwrite=True)
 
 # change the order and see if we get identical results
 trafo_entry = depointerfy(exfor_entry)
 trafo_entry = unitfy(trafo_entry)
 trafo_entry = uncommonfy(trafo_entry)
-parser.writefile('entry_21308_transformed2.txt', trafo_entry, overwrite=True)
+parser.writefile("entry_21308_transformed2.txt", trafo_entry, overwrite=True)
 
 
 # conversion of compound units in compound quantities
-exfor_entry = parser.readfile(TEST_DATA / 'entry_T0408.txt')
+exfor_entry = parser.readfile(TEST_DATA / "entry_T0408.txt")
 trafo_entry = unitfy(exfor_entry)
-parser.writefile('entry_T0408_unitfy.txt', trafo_entry, overwrite=True)
+parser.writefile("entry_T0408_unitfy.txt", trafo_entry, overwrite=True)
 
-exfor_entry = parser.readfile(TEST_DATA / 'entry_23245.txt')
+exfor_entry = parser.readfile(TEST_DATA / "entry_23245.txt")
 trafo_entry = unitfy(exfor_entry)
-parser.writefile('entry_23245_unitfy.txt', trafo_entry, overwrite=True)
+parser.writefile("entry_23245_unitfy.txt", trafo_entry, overwrite=True)
 
 
 # example with detextify transformer
-exfor_entry = parser.readfile(TEST_DATA / 'entry_T0408.txt')
+exfor_entry = parser.readfile(TEST_DATA / "entry_T0408.txt")
 trafo_entry = detextify(exfor_entry)
 # with detextify we are transforming the EXFOR entry in
 # a way that does not allow the conversion back anymore.
 # In an EXFOR entry code and free text are by definition
 # together in a single string.
-#parser.writefile('entry_T0408_detextify.txt', trafo_entry, overwrite=True)
+# parser.writefile('entry_T0408_detextify.txt', trafo_entry, overwrite=True)
 pretty = json.dumps(trafo_entry, indent=4)
 print(pretty)
-

--- a/exfor_parserpy/exfor_parser.py
+++ b/exfor_parserpy/exfor_parser.py
@@ -8,13 +8,20 @@
 #
 ############################################################
 from os.path import exists
-from .exfor_primitives import (read_str_field, write_str_field,
-        read_pointered_field, read_int_field, read_fields, write_fields,
-        update_dic, write_bib_element)
+from .exfor_primitives import (
+    read_str_field,
+    write_str_field,
+    read_pointered_field,
+    read_int_field,
+    read_fields,
+    write_fields,
+    update_dic,
+    write_bib_element,
+)
 from .utils.custom_iterators import search_for_field
 
-class ExforBaseParser(object):
 
+class ExforBaseParser(object):
     def parse_bib_element(self, lines=None, datadic=None, inverse=False, ofs=0):
         if not inverse:
             fieldkey, pointer = read_pointered_field(lines[ofs], 0)
@@ -22,19 +29,19 @@ class ExforBaseParser(object):
             ofs += 1
             if not pointer:
                 nextfieldkey = read_str_field(lines[ofs], 0)
-                while nextfieldkey == '':
-                    content += '\n' + read_str_field(lines[ofs], 1, 5)
+                while nextfieldkey == "":
+                    content += "\n" + read_str_field(lines[ofs], 1, 5)
                     ofs += 1
                     nextfieldkey = read_str_field(lines[ofs], 0)
                 return {fieldkey: content}, ofs
             else:
                 pointerdic = {}
                 nextfield, nextpointer = read_pointered_field(lines[ofs], 0)
-                while nextfield == '':
-                    if nextfield == '' and nextpointer:
+                while nextfield == "":
+                    if nextfield == "" and nextpointer:
                         pointerdic[pointer] = content
                         pointer = nextpointer
-                        content = ''
+                        content = ""
                     content += read_str_field(lines[ofs], 1, 5)
                     ofs += 1
                     nextfield, nextpointer = read_pointered_field(lines[ofs], 0)
@@ -50,8 +57,11 @@ class ExforBaseParser(object):
                 else:
                     first = True
                     for pointer in content:
-                        lines.extend(write_bib_element(fieldkey, pointer, content[pointer],
-                                                       outkey=first))
+                        lines.extend(
+                            write_bib_element(
+                                fieldkey, pointer, content[pointer], outkey=first
+                            )
+                        )
                         first = False
             ofs += len(lines)
             return lines, ofs
@@ -59,85 +69,91 @@ class ExforBaseParser(object):
     def parse_bib(self, lines=None, datadic=None, inverse=False, ofs=0):
         if not inverse:
             datadic = {}
-            if read_str_field(lines[ofs], 0) != 'BIB':
-                raise TypeError('not a BIB block')
+            if read_str_field(lines[ofs], 0) != "BIB":
+                raise TypeError("not a BIB block")
             ofs += 1
-            while ofs < len(lines) and read_str_field(lines[ofs], 0) != 'ENDBIB':
+            while ofs < len(lines) and read_str_field(lines[ofs], 0) != "ENDBIB":
                 field, ofs = self.parse_bib_element(lines, datadic, inverse, ofs)
                 datadic.update(field)
             return datadic, ofs
         # inverse transform
         else:
             lines = []
-            lines.append(write_str_field('', 0, 'BIB'))
+            lines.append(write_str_field("", 0, "BIB"))
             ofs += 1
             for key, value in datadic.items():
-                curlines, ofs = self.parse_bib_element(lines, {key: value}, inverse, ofs)
+                curlines, ofs = self.parse_bib_element(
+                    lines, {key: value}, inverse, ofs
+                )
                 lines.extend(curlines)
-            lines.append(write_str_field('', 0, 'ENDBIB'))
+            lines.append(write_str_field("", 0, "ENDBIB"))
             ofs += 1
             return lines, ofs
 
-    def parse_common_or_data(self, lines=None, datadic=None, inverse=False, ofs=0,
-                             what='common'):
+    def parse_common_or_data(
+        self, lines=None, datadic=None, inverse=False, ofs=0, what="common"
+    ):
         if not inverse:
             datadic = {}
             if read_str_field(lines[ofs], 0) != what.upper():
-                raise TypeError(f'not a {what.upper()} block')
+                raise TypeError(f"not a {what.upper()} block")
             numfields = read_int_field(lines[ofs], 1)
-            numlines = read_int_field(lines[ofs], 2) if what == 'data' else 1
+            numlines = read_int_field(lines[ofs], 2) if what == "data" else 1
             ofs += 1
 
-            descrs, ofs = read_fields(lines, numfields, ofs, dtype='strp')
-            units, ofs = read_fields(lines, numfields, ofs, dtype='str')
+            descrs, ofs = read_fields(lines, numfields, ofs, dtype="strp")
+            units, ofs = read_fields(lines, numfields, ofs, dtype="str")
             unit_dic = {}
             for i, (curdescr, pointer) in enumerate(descrs):
                 update_dic(unit_dic, curdescr, pointer, units[i], arr=False)
 
             value_dic = {}
             for currow in range(numlines):
-                values, ofs = read_fields(lines, numfields, ofs, dtype='float')
+                values, ofs = read_fields(lines, numfields, ofs, dtype="float")
                 for i, (curdescr, pointer) in enumerate(descrs):
-                    update_dic(value_dic, curdescr, pointer, values[i], arr=(what=='data'))
+                    update_dic(
+                        value_dic, curdescr, pointer, values[i], arr=(what == "data")
+                    )
 
-            resdic = {'UNIT': unit_dic, 'DATA': value_dic}
+            resdic = {"UNIT": unit_dic, "DATA": value_dic}
             return resdic, ofs
         # inverse transform
         else:
             lines = []
-            lines.append(write_str_field('', 0,
-                             'COMMON' if what=='common' else 'DATA'))
+            lines.append(
+                write_str_field("", 0, "COMMON" if what == "common" else "DATA")
+            )
             ofs += 1
             # prepare descrs, unit and value lists
             descrs = []
             units = []
-            for fieldkey, cont in datadic['UNIT'].items():
+            for fieldkey, cont in datadic["UNIT"].items():
                 if isinstance(cont, dict):
                     for pointer in cont:
                         descrs.append((fieldkey, pointer))
-                        units.append(datadic['UNIT'][fieldkey][pointer])
+                        units.append(datadic["UNIT"][fieldkey][pointer])
                 else:
                     descrs.append((fieldkey, None))
-                    units.append(datadic['UNIT'][fieldkey])
+                    units.append(datadic["UNIT"][fieldkey])
             # write out the header
-            curlines = write_fields(descrs, ofs, dtype='strp')
+            curlines = write_fields(descrs, ofs, dtype="strp")
             lines.extend(curlines)
-            curlines = write_fields(units, ofs, dtype='str')
+            curlines = write_fields(units, ofs, dtype="str")
             lines.extend(curlines)
             # write the data
-            if what == 'common':
+            if what == "common":
                 values = []
-                for fieldkey, cont in datadic['UNIT'].items():
+                for fieldkey, cont in datadic["UNIT"].items():
                     if isinstance(cont, dict):
                         for pointer in cont:
-                            values.append(datadic['DATA'][fieldkey][pointer])
+                            values.append(datadic["DATA"][fieldkey][pointer])
                     else:
-                        values.append(datadic['DATA'][fieldkey])
-                curlines = write_fields(values, ofs, dtype='float')
+                        values.append(datadic["DATA"][fieldkey])
+                curlines = write_fields(values, ofs, dtype="float")
                 lines.extend(curlines)
                 ofs += len(curlines)
-            elif what == 'data':
-                curdic = datadic['DATA']
+            elif what == "data":
+                curdic = datadic["DATA"]
                 # get a column of the DATA section table
                 # to determine the numbe of rows
                 while isinstance(curdic, dict):
@@ -148,47 +164,53 @@ class ExforBaseParser(object):
                 # cycle through the columns
                 for currow in range(numlines):
                     values = []
-                    for fieldkey, cont in datadic['UNIT'].items():
+                    for fieldkey, cont in datadic["UNIT"].items():
                         if isinstance(cont, dict):
                             for pointer in cont:
-                                values.append(datadic['DATA'][fieldkey][pointer][currow])
+                                values.append(
+                                    datadic["DATA"][fieldkey][pointer][currow]
+                                )
                         else:
-                            values.append(datadic['DATA'][fieldkey][currow])
-                    curlines = write_fields(values, ofs, dtype='float')
+                            values.append(datadic["DATA"][fieldkey][currow])
+                    curlines = write_fields(values, ofs, dtype="float")
                     lines.extend(curlines)
                     ofs += len(curlines)
-            lines.append(write_str_field('', 0,
-                             'ENDCOMMON' if what=='common' else 'ENDDATA'))
+            lines.append(
+                write_str_field("", 0, "ENDCOMMON" if what == "common" else "ENDDATA")
+            )
             ofs += 1
             return lines, ofs
 
-    def parse_subentry(self, lines=None, datadic=None, inverse=False, ofs=0,
-                       auxinfo=None):
+    def parse_subentry(
+        self, lines=None, datadic=None, inverse=False, ofs=0, auxinfo=None
+    ):
         if not inverse:
             datadic = {}
-            if read_str_field(lines[ofs], 0) != 'SUBENT':
-                raise TypeError('not a SUBENT block')
+            if read_str_field(lines[ofs], 0) != "SUBENT":
+                raise TypeError("not a SUBENT block")
             if auxinfo is None:
                 auxinfo = {}
-            auxinfo['subentryid'] = read_str_field(lines[ofs], 1).strip()
-            datadic['__entryid'] = auxinfo['entryid']
-            datadic['__subentid'] = auxinfo['subentryid']
+            auxinfo["subentryid"] = read_str_field(lines[ofs], 1).strip()
+            datadic["__entryid"] = auxinfo["entryid"]
+            datadic["__subentid"] = auxinfo["subentryid"]
             ofs += 1
-            while ofs < len(lines) and read_str_field(lines[ofs], 0) != 'ENDSUBENT':
+            while ofs < len(lines) and read_str_field(lines[ofs], 0) != "ENDSUBENT":
                 curfield = read_str_field(lines[ofs], 0)
-                if curfield == 'BIB':
+                if curfield == "BIB":
                     bibsec, ofs = self.parse_bib(lines, datadic, inverse, ofs)
-                    datadic['BIB'] = bibsec
+                    datadic["BIB"] = bibsec
 
-                if curfield == 'COMMON':
-                    commonsec, ofs = self.parse_common_or_data(lines, datadic, inverse, ofs,
-                                                          what='common')
-                    datadic['COMMON'] = commonsec
+                if curfield == "COMMON":
+                    commonsec, ofs = self.parse_common_or_data(
+                        lines, datadic, inverse, ofs, what="common"
+                    )
+                    datadic["COMMON"] = commonsec
 
-                if curfield == 'DATA':
-                    datasec, ofs = self.parse_common_or_data(lines, datadic, inverse, ofs,
-                                                        what='data')
-                    datadic['DATA'] = datasec
+                if curfield == "DATA":
+                    datasec, ofs = self.parse_common_or_data(
+                        lines, datadic, inverse, ofs, what="data"
+                    )
+                    datadic["DATA"] = datasec
                 else:
                     ofs += 1
             # advance ofs after ENDSUBENT
@@ -196,47 +218,50 @@ class ExforBaseParser(object):
             return datadic, ofs
         else:
             lines = []
-            subent_line = write_str_field('', 0, 'SUBENT')
-            subent_line = write_str_field(subent_line, 1, datadic['__subentid'],
-                                          align='right')
+            subent_line = write_str_field("", 0, "SUBENT")
+            subent_line = write_str_field(
+                subent_line, 1, datadic["__subentid"], align="right"
+            )
             lines.append(subent_line)
             ofs += 1
-            if 'BIB' in datadic:
-                curdic = datadic['BIB']
+            if "BIB" in datadic:
+                curdic = datadic["BIB"]
                 curlines, ofs = self.parse_bib(lines, curdic, inverse, ofs)
                 lines.extend(curlines)
-            if 'COMMON' in datadic:
-                curdic = datadic['COMMON']
-                curlines, ofs = self.parse_common_or_data(lines, curdic, inverse, ofs,
-                                                     what='common')
+            if "COMMON" in datadic:
+                curdic = datadic["COMMON"]
+                curlines, ofs = self.parse_common_or_data(
+                    lines, curdic, inverse, ofs, what="common"
+                )
                 lines.extend(curlines)
             else:
-                lines.append(write_str_field('', 0, 'NOCOMMON'))
+                lines.append(write_str_field("", 0, "NOCOMMON"))
                 ofs += 1
-            if 'DATA' in datadic:
-                curdic = datadic['DATA']
-                curlines, ofs = self.parse_common_or_data(lines, curdic, inverse, ofs,
-                                                     what='data')
+            if "DATA" in datadic:
+                curdic = datadic["DATA"]
+                curlines, ofs = self.parse_common_or_data(
+                    lines, curdic, inverse, ofs, what="data"
+                )
                 lines.extend(curlines)
-            lines.append(write_str_field('', 0, 'ENDSUBENT'))
+            lines.append(write_str_field("", 0, "ENDSUBENT"))
             return lines, ofs
 
-    def parse_entry(self, lines=None, datadic=None, inverse=False, ofs=0,
-                    auxinfo=None):
+    def parse_entry(self, lines=None, datadic=None, inverse=False, ofs=0, auxinfo=None):
         if not inverse:
-            datadic = {'subentries': []}
-            if read_str_field(lines[ofs], 0) != 'ENTRY':
-                raise TypeError('not an ENTRY block')
+            datadic = {"subentries": []}
+            if read_str_field(lines[ofs], 0) != "ENTRY":
+                raise TypeError("not an ENTRY block")
             if auxinfo is None:
                 auxinfo = {}
-            auxinfo['entryid'] = read_str_field(lines[ofs], 1).strip()
+            auxinfo["entryid"] = read_str_field(lines[ofs], 1).strip()
             ofs += 1
             datadic = {}
-            while ofs < len(lines) and read_str_field(lines[ofs], 0) != 'ENDENTRY':
-                if read_str_field(lines[ofs], 0) == 'SUBENT':
+            while ofs < len(lines) and read_str_field(lines[ofs], 0) != "ENDENTRY":
+                if read_str_field(lines[ofs], 0) == "SUBENT":
                     subentid = read_str_field(lines[ofs], 1).strip()
-                    subent, ofs = self.parse_subentry(lines, None, inverse, ofs,
-                                                      auxinfo=auxinfo)
+                    subent, ofs = self.parse_subentry(
+                        lines, None, inverse, ofs, auxinfo=auxinfo
+                    )
                     datadic[subentid] = subent
                 else:
                     ofs += 1
@@ -248,18 +273,18 @@ class ExforBaseParser(object):
             # locate the first subentry id among the subentries
             # in the current entry dictionary and extract the
             # entry id from that
-            first_subentid = search_for_field(datadic, '__subentid')
+            first_subentid = search_for_field(datadic, "__subentid")
             if not first_subentid:
-                raise IndexError('No subentry identification number found')
+                raise IndexError("No subentry identification number found")
             entryid = first_subentid[:5]
-            entry_line = write_str_field('', 0, 'ENTRY')
-            entry_line = write_str_field(entry_line, 1, entryid, align='right')
+            entry_line = write_str_field("", 0, "ENTRY")
+            entry_line = write_str_field(entry_line, 1, entryid, align="right")
             lines.append(entry_line)
             ofs += 1
             for cursubent, curdic in datadic.items():
                 curlines, ofs = self.parse_subentry(lines, curdic, inverse, ofs)
                 lines.extend(curlines)
-            lines.append(write_str_field('', 0, 'ENDENTRY'))
+            lines.append(write_str_field("", 0, "ENDENTRY"))
             ofs += 1
             return lines, ofs
 
@@ -267,7 +292,7 @@ class ExforBaseParser(object):
         if not inverse:
             datadic = {}
             while ofs < len(lines):
-                if read_str_field(lines[ofs], 0) == 'ENTRY':
+                if read_str_field(lines[ofs], 0) == "ENTRY":
                     entryid = read_str_field(lines[ofs], 1).strip()
                     entry, ofs = self.parse_entry(lines, None, inverse, ofs)
                     datadic[entryid] = entry
@@ -288,8 +313,10 @@ class ExforBaseParser(object):
         elif isinstance(cont, list):
             lines = cont
         else:
-            raise TypeError('argument must be either string with ' +
-                            'EXFOR entry or list of lines with EXFOR entry')
+            raise TypeError(
+                "argument must be either string with "
+                + "EXFOR entry or list of lines with EXFOR entry"
+            )
         exfor_dic, _ = self.parse(lines=lines)
         return exfor_dic
 
@@ -298,15 +325,14 @@ class ExforBaseParser(object):
         return lines
 
     def readfile(self, filename):
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             cont = f.readlines()
         return self.read(cont)
 
     def writefile(self, filename, exfor_dic, overwrite=False):
         if not overwrite and exists(filename):
-            raise FileExistsError(f'The file {filename} already exists')
+            raise FileExistsError(f"The file {filename} already exists")
         lines = self.write(exfor_dic)
-        lines = [l.rstrip('\n').rstrip('\r') + '\n' for l in lines]
-        with open(filename, 'w') as f:
+        lines = [l.rstrip("\n").rstrip("\r") + "\n" for l in lines]
+        with open(filename, "w") as f:
             f.writelines(lines)
-

--- a/exfor_parserpy/exfor_primitives.py
+++ b/exfor_parserpy/exfor_primitives.py
@@ -9,106 +9,119 @@
 ############################################################
 from .utils.fortran_utils import fortstr2float
 
+
 def read_str_field(line, pos, width=1, trim=True):
-    valstr = line[pos*11:(pos+width)*11]
+    valstr = line[pos * 11 : (pos + width) * 11]
     return valstr.rstrip() if trim else valstr
 
-def write_str_field(line, pos, mystr, width=1, align='left'):
+
+def write_str_field(line, pos, mystr, width=1, align="left"):
     line = line.ljust(66)
-    newline = line[:pos*11] if pos > 0 else ''
-    if align == 'left':
-        newline += mystr.ljust(width*11)
+    newline = line[: pos * 11] if pos > 0 else ""
+    if align == "left":
+        newline += mystr.ljust(width * 11)
     else:
-        newline += mystr.rjust(width*11)
-    newline += line[(pos+width)*11:]
+        newline += mystr.rjust(width * 11)
+    newline += line[(pos + width) * 11 :]
     return newline
+
 
 def read_int_field(line, pos, width=1):
     valstr = read_str_field(line, pos, width)
     return int(valstr)
 
+
 def write_int_field(line, pos, value, width=1):
-    valstr = '{:<11d}'.format(value).ljust(width*11)
+    valstr = "{:<11d}".format(value).ljust(width * 11)
     return write_str_field(line, pos, valstr, width)
+
 
 def read_float_field(line, pos, width=1):
     valstr = read_str_field(line, pos, width)
-    return fortstr2float(valstr) if valstr != '' else None
+    return fortstr2float(valstr) if valstr != "" else None
+
 
 def write_float_field(line, pos, num, width=1):
     if num is not None:
-        valstr = '{:<11g}'.format(num).ljust(width*11)
+        valstr = "{:<11g}".format(num).ljust(width * 11)
     else:
-        valstr = ''
+        valstr = ""
     return write_str_field(line, pos, valstr, width)
 
+
 def get_pointer(field):
-    return field[11] if field[11] != ' ' else None
+    return field[11] if field[11] != " " else None
+
 
 def read_pointered_field(line, pos):
     valstr = read_str_field(line, pos, trim=False)
-    pointer = valstr[10] if len(valstr)>=11 and valstr[10] != ' ' else None
+    pointer = valstr[10] if len(valstr) >= 11 and valstr[10] != " " else None
     fieldkey = valstr[:10].strip()
     return fieldkey, pointer
 
+
 def write_pointered_field(line, pos, fieldkey, pointer, outkey=True):
-    valstr = fieldkey.ljust(10) if outkey else ' '*10
-    valstr+= pointer if pointer else ' '
+    valstr = fieldkey.ljust(10) if outkey else " " * 10
+    valstr += pointer if pointer else " "
     return write_str_field(line, pos, valstr)
+
 
 def write_bib_element(fieldkey, pointer, content, outkey=True):
     content_lines = content.splitlines()
-    curline = write_pointered_field('', 0, fieldkey, pointer, outkey)
+    curline = write_pointered_field("", 0, fieldkey, pointer, outkey)
     curline = write_str_field(curline, 1, content_lines[0], width=5)
     newlines = [curline]
     if len(content_lines) > 1:
         for i, curcont in enumerate(content_lines[1:]):
-            curline = write_str_field('', 1, curcont, width=5)
+            curline = write_str_field("", 1, curcont, width=5)
             newlines.append(curline)
     return newlines
 
-def read_fields(lines, num, ofs, dtype='str'):
+
+def read_fields(lines, num, ofs, dtype="str"):
     fields = []
     while num > 0:
         curnum = min(6, num)
         curline = lines[ofs]
         for i in range(curnum):
-            if dtype == 'strp':
+            if dtype == "strp":
                 curfield = read_pointered_field(curline, i)
-            elif dtype == 'str':
-                curfield = read_str_field(curline, i) 
-            elif dtype == 'int':
+            elif dtype == "str":
+                curfield = read_str_field(curline, i)
+            elif dtype == "int":
                 curfield = read_int_field(curline, i)
-            elif dtype == 'float':
+            elif dtype == "float":
                 curfield = read_float_field(curline, i)
             else:
-                raise TypeError('unknown dtype')
+                raise TypeError("unknown dtype")
             fields.append(curfield)
         ofs += 1
         num -= curnum
     return fields, ofs
 
-def write_fields(fields, ofs, dtype='str'):
+
+def write_fields(fields, ofs, dtype="str"):
     num = 0
     lines = []
     while num < len(fields):
-        curnum = min(6, len(fields)-num)
-        curline = ''
+        curnum = min(6, len(fields) - num)
+        curline = ""
         for i in range(curnum):
-            curfield = fields[num+i]
-            if dtype == 'strp':
+            curfield = fields[num + i]
+            if dtype == "strp":
                 curline = write_pointered_field(curline, i, curfield[0], curfield[1])
-            elif dtype == 'str':
+            elif dtype == "str":
                 curline = write_str_field(curline, i, curfield)
-            elif dtype == 'int':
+            elif dtype == "int":
                 curline = write_int_field(curline, i, curfield)
-            elif dtype == 'float':
+            elif dtype == "float":
                 curline = write_float_field(curline, i, curfield)
             else:
-                raise TypeError('unknown dtype')
+                raise TypeError("unknown dtype")
         lines.append(curline)
         num += curnum
     return lines
+
 
 def update_dic(dic, field, pointer, value, arr=False):
     if not pointer:
@@ -125,4 +138,3 @@ def update_dic(dic, field, pointer, value, arr=False):
             dic[field].setdefault(pointer, [])
             dic[field][pointer].append(value)
     return dic
-

--- a/exfor_parserpy/trafos/depointerfy.py
+++ b/exfor_parserpy/trafos/depointerfy.py
@@ -35,7 +35,7 @@ def depointerfy(exfor_dic, delete_pointered_subents=True):
             if contains_pointers(fieldcont):
                 curpointers = set(fieldcont.keys())
                 if len(pointers) != 0 and pointers != curpointers:
-                    raise IndexError(f'Inconsistent pointers in subentry {subentid}')
+                    raise IndexError(f"Inconsistent pointers in subentry {subentid}")
                 pointers = curpointers
         # duplicate subentries with pointers
         # and use the values of a specific pointer in each of them.
@@ -47,7 +47,7 @@ def depointerfy(exfor_dic, delete_pointered_subents=True):
                     parent_of_field[fieldname] = fieldcont[curpointer]
             # construct an extended subentry id
             pointered_subentid = subentid + curpointer
-            newsubent['__subentid'] = pointered_subentid
+            newsubent["__subentid"] = pointered_subentid
             parent_of_subent[pointered_subentid] = newsubent
         # after all pointers have been processed,
         # delete the old subentry with pointers if desired
@@ -55,4 +55,3 @@ def depointerfy(exfor_dic, delete_pointered_subents=True):
             del parent_of_subent[subentid]
     # yay, we are done
     return ret_dic
-

--- a/exfor_parserpy/trafos/detextify.py
+++ b/exfor_parserpy/trafos/detextify.py
@@ -15,7 +15,7 @@
 
 from copy import deepcopy
 from ..utils.custom_iterators import exfor_iterator3
-from ..utils.convenience import is_subentry, contains_pointers 
+from ..utils.convenience import is_subentry, contains_pointers
 import re
 
 
@@ -26,19 +26,19 @@ def detextify(exfor_dic, keep_original_field=False):
     for subentid, subent, parent_of_subent in outeriter:
         if not is_subentry(subent, subentid):
             continue
-        if 'BIB' not in subent:
+        if "BIB" not in subent:
             continue
-        bibsec = subent['BIB']
+        bibsec = subent["BIB"]
         # the tupling is done because otherwise the
         # iterator complains about changes to the dictionary
         for fieldname, fieldcont in tuple(bibsec.items()):
             # we skip for the time being the splitting
             # of the REACTION field due to the increased
             # complexity of the "reaction algebra"
-            if fieldname == 'REACTION':
+            if fieldname == "REACTION":
                 continue
-            code_fieldname = fieldname + '_codes'
-            text_fieldname = fieldname + '_texts'
+            code_fieldname = fieldname + "_codes"
+            text_fieldname = fieldname + "_texts"
             if contains_pointers(fieldcont):
                 for curpointer, fieldcont2 in fieldcont.items():
                     code_list, text_list = split_code_and_text(fieldcont2)
@@ -54,18 +54,18 @@ def detextify(exfor_dic, keep_original_field=False):
                 del bibsec[fieldname]
         return ret_dic
 
+
 def split_code_and_text(string):
-    m = re.findall(r'\(([^)]+)\)([^(]*)', string)
+    m = re.findall(r"\(([^)]+)\)([^(]*)", string)
     code_list = []
     text_list = []
     if not m:
-        code_list.append('')
+        code_list.append("")
         text_list.append(string)
     else:
         for token in m:
             code = token[0].strip()
-            text = token[1].strip() 
+            text = token[1].strip()
             code_list.append(code)
             text_list.append(text)
     return code_list, text_list
-

--- a/exfor_parserpy/trafos/uncommonfy.py
+++ b/exfor_parserpy/trafos/uncommonfy.py
@@ -11,8 +11,12 @@
 
 from copy import deepcopy
 from ..utils.custom_iterators import exfor_iterator2
-from ..utils.convenience import (has_common_block, has_data_block,
-        count_points_in_datablock, merge_common_into_datablock)
+from ..utils.convenience import (
+    has_common_block,
+    has_data_block,
+    count_points_in_datablock,
+    merge_common_into_datablock,
+)
 
 
 def uncommonfy(exfor_dic, delete_common=True):
@@ -35,27 +39,26 @@ def uncommonfy(exfor_dic, delete_common=True):
         # the assumption here is that DATA and COMMON
         # blocks are at the top level of a subentry
         # so we know that curkey contains the subentry accession number.
-        datablock = curdic['DATA']
+        datablock = curdic["DATA"]
         numpoints = count_points_in_datablock(datablock)
         # first incorporate the common block of the first subentry.
         # we only match the first 8 characters to be robust
         # against added suffixes due to pointers or similar
-        first_subid = curkey[:5] + '001'
+        first_subid = curkey[:5] + "001"
         first_subid_ext = first_subid + curkey[8:]
         if first_subid_ext in common_dic:
             first_subid = first_subid_ext
 
         if first_subid in common_dic:
-            commonblock = common_dic[first_subid]['COMMON']
+            commonblock = common_dic[first_subid]["COMMON"]
             merge_common_into_datablock(datablock, commonblock)
         # deal with the common block of the current subentry
         if curkey in common_dic:
-            commonblock = common_dic[curkey]['COMMON']
+            commonblock = common_dic[curkey]["COMMON"]
             merge_common_into_datablock(datablock, commonblock)
     # finally delete all the common blocks if desired
     if delete_common:
         for k, d in common_dic.items():
-            del d['COMMON']
+            del d["COMMON"]
 
     return ret_dic
-

--- a/exfor_parserpy/trafos/unitfy.py
+++ b/exfor_parserpy/trafos/unitfy.py
@@ -8,40 +8,39 @@
 #
 ############################################################
 from copy import deepcopy
-from ..utils import (apply_factor, eval_arithm_expr,
-                     exfor_iterator, is_dic, is_str)
+from ..utils import apply_factor, eval_arithm_expr, exfor_iterator, is_dic, is_str
 
 
 FACTORS_DIC = {
     # converson factors to obtain MB
-    'B' : 1e3,
-    'MB': 1,
-    'MICRO-B': 1e-3,
-    'MU-B': 1e-3,
+    "B": 1e3,
+    "MB": 1,
+    "MICRO-B": 1e-3,
+    "MU-B": 1e-3,
     # conversion factors to obtain MEV
-    'MILLI-EV': 1e-9,
-    'EV':  1e-6,
-    'KEV': 1e-3,
-    'MEV': 1,
-    'GEV': 1e3
+    "MILLI-EV": 1e-9,
+    "EV": 1e-6,
+    "KEV": 1e-3,
+    "MEV": 1,
+    "GEV": 1e3,
 }
 
 # unit replacement
 UNIT_DIC = {
     # xs type units
-    'B' : 'MB',
-    'MB': 'MB',
-    'MICRO-B': 'MB',
+    "B": "MB",
+    "MB": "MB",
+    "MICRO-B": "MB",
     # same as MICRO-B but used
     # in differential quantities
     # due to field size limitation
-    'MU-B': 'MB',
+    "MU-B": "MB",
     # energy type units
-    'MILLI-EV': 'MEV',
-    'EV' : 'MEV',
-    'KEV': 'MEV',
-    'MEV': 'MEV',
-    'GEV': 'MEV'
+    "MILLI-EV": "MEV",
+    "EV": "MEV",
+    "KEV": "MEV",
+    "MEV": "MEV",
+    "GEV": "MEV",
 }
 
 
@@ -55,30 +54,35 @@ def unitfy(exfor_dic):
     # we discard the minus sign as an operator
     # because it appears in EXFOR in symbol names
     # e.g., PER-CENT, ERR-2
-    myops = '+*/'
+    myops = "+*/"
     # go through all dictionaries and identify
     # physics data indicated by the presence of
     # the UNIT and DATA dictionaries
     for curdic in exfor_iterator(ret_dic):
-        if 'UNIT' in curdic:
-            if 'DATA' not in curdic:
-                raise TypeError('If UNIT is present, we also expect a DATA key')
-            for curfield, curunit in curdic['UNIT'].items():
+        if "UNIT" in curdic:
+            if "DATA" not in curdic:
+                raise TypeError("If UNIT is present, we also expect a DATA key")
+            for curfield, curunit in curdic["UNIT"].items():
                 if is_str(curunit):
                     fact = eval_arithm_expr(curunit, FACTORS_DIC, comp=True, ops=myops)
                     newunit = eval_arithm_expr(curunit, UNIT_DIC, comp=False, ops=myops)
-                    newdata = apply_factor(curdic['DATA'][curfield], fact)
-                    curdic['UNIT'][curfield] = newunit
-                    curdic['DATA'][curfield] = newdata
+                    newdata = apply_factor(curdic["DATA"][curfield], fact)
+                    curdic["UNIT"][curfield] = newunit
+                    curdic["DATA"][curfield] = newdata
                 elif is_dic(curunit):
                     # we deal with pointers
                     for curpt, curunit in curunit.items():
-                        fact = eval_arithm_expr(curunit, FACTORS_DIC, comp=True, ops=myops)
-                        newunit = eval_arithm_expr(curunit, UNIT_DIC, comp=False, ops=myops)
-                        newdata = apply_factor(curdic['DATA'][curfield][curpt], fact)
-                        curdic['UNIT'][curfield][curpt] = newunit
-                        curdic['DATA'][curfield][curpt] = newdata
+                        fact = eval_arithm_expr(
+                            curunit, FACTORS_DIC, comp=True, ops=myops
+                        )
+                        newunit = eval_arithm_expr(
+                            curunit, UNIT_DIC, comp=False, ops=myops
+                        )
+                        newdata = apply_factor(curdic["DATA"][curfield][curpt], fact)
+                        curdic["UNIT"][curfield][curpt] = newunit
+                        curdic["DATA"][curfield][curpt] = newdata
                 else:
-                    raise TypeError('expected a string or a dictionary in the UNIT field')
+                    raise TypeError(
+                        "expected a string or a dictionary in the UNIT field"
+                    )
     return ret_dic
-

--- a/exfor_parserpy/utils/arithmetic_expr_parsing.py
+++ b/exfor_parserpy/utils/arithmetic_expr_parsing.py
@@ -14,12 +14,12 @@
 # the function to be invoked by the user here is
 # eval_arithm_expr
 
+
 def get_number(expr, vardic, ofs, comp, ops):
-    curstr = ''
-    while (ofs < len(expr) and
-           expr[ofs] not in ' ' + ops): 
+    curstr = ""
+    while ofs < len(expr) and expr[ofs] not in " " + ops:
         curstr += expr[ofs]
-        ofs +=1
+        ofs += 1
     # try to obtain a number
     if comp:
         try:
@@ -40,77 +40,85 @@ def get_number(expr, vardic, ofs, comp, ops):
             curstr = vardic[curstr]
         return curstr, ofs
 
+
 def get_next_char(expr, ofs):
-    while (ofs < len(expr) and not expr[ofs].isdigit() and
-           not expr[ofs].isalpha() and expr[ofs] not in ('+','-','*','/','(',')')):
+    while (
+        ofs < len(expr)
+        and not expr[ofs].isdigit()
+        and not expr[ofs].isalpha()
+        and expr[ofs] not in ("+", "-", "*", "/", "(", ")")
+    ):
         ofs += 1
     if ofs == len(expr):
         return None, ofs
     else:
         return expr[ofs], ofs
 
+
 def eval_symbol(expr, vardic, ofs, comp, ops):
     next_char, ofs = get_next_char(expr, ofs)
-    if next_char == '-':
-        leftval, ofs = eval_symbol(expr, vardic, ofs+1, comp, ops)
+    if next_char == "-":
+        leftval, ofs = eval_symbol(expr, vardic, ofs + 1, comp, ops)
         if comp:
             leftval = -leftval
         else:
-            leftval = '-' + leftval
-    elif next_char == '(':
-        leftval, ofs = eval_addition(expr, vardic, ofs+1, comp, ops)
+            leftval = "-" + leftval
+    elif next_char == "(":
+        leftval, ofs = eval_addition(expr, vardic, ofs + 1, comp, ops)
         next_char, ofs = get_next_char(expr, ofs)
-        if next_char != ')':
-            raise ValueError('bracket not closed')
+        if next_char != ")":
+            raise ValueError("bracket not closed")
         if not comp:
-            leftval = '(' + leftval + ')'
+            leftval = "(" + leftval + ")"
         ofs += 1
-    elif next_char.isalpha() or next_char.isdigit() or '-':
-        leftval, ofs = get_number(expr, vardic, ofs, comp, ops) 
+    elif next_char.isalpha() or next_char.isdigit() or "-":
+        leftval, ofs = get_number(expr, vardic, ofs, comp, ops)
     # division needs to be treated specially
     next_char, ofs = get_next_char(expr, ofs)
-    if next_char == '/':
-        rightval, ofs = eval_symbol(expr, vardic, ofs+1, comp, ops)
+    if next_char == "/":
+        rightval, ofs = eval_symbol(expr, vardic, ofs + 1, comp, ops)
         if comp:
-            return leftval / rightval, ofs 
+            return leftval / rightval, ofs
         else:
-            return leftval + '/' + rightval, ofs
+            return leftval + "/" + rightval, ofs
     else:
         return leftval, ofs
+
 
 def eval_product(expr, vardic, ofs, comp, ops):
     leftval, ofs = eval_symbol(expr, vardic, ofs, comp, ops)
     next_char, ofs = get_next_char(expr, ofs)
-    if next_char == '*':
-        rightval, ofs = eval_product(expr, vardic, ofs+1, comp, ops)
+    if next_char == "*":
+        rightval, ofs = eval_product(expr, vardic, ofs + 1, comp, ops)
         if comp:
             return leftval * rightval, ofs
         else:
-            return leftval + '*' + rightval, ofs
+            return leftval + "*" + rightval, ofs
     else:
         return leftval, ofs
 
-def eval_addition(expr, vardic, ofs, comp, ops): 
+
+def eval_addition(expr, vardic, ofs, comp, ops):
     leftval, ofs = eval_product(expr, vardic, ofs, comp, ops)
     next_char, ofs = get_next_char(expr, ofs)
-    if next_char == '+':
-        rightval, ofs = eval_addition(expr, vardic, ofs+1, comp, ops) 
+    if next_char == "+":
+        rightval, ofs = eval_addition(expr, vardic, ofs + 1, comp, ops)
         if comp:
             return leftval + rightval, ofs
         else:
-            return leftval + '+' + rightval, ofs
-    elif next_char == '-':
-        rightval, ofs = eval_addition(expr, vardic, ofs+1, comp, ops)
+            return leftval + "+" + rightval, ofs
+    elif next_char == "-":
+        rightval, ofs = eval_addition(expr, vardic, ofs + 1, comp, ops)
         if comp:
             return leftval - rightval, ofs
         else:
-            return leftval + '-' + rightval, ofs
+            return leftval + "-" + rightval, ofs
     else:
         return leftval, ofs
 
-def eval_arithm_expr(expr, vardic=None, comp=True, ops='+-*/'):
+
+def eval_arithm_expr(expr, vardic=None, comp=True, ops="+-*/"):
     if vardic is None:
         vardic = {}
     value, _ = eval_addition(expr, vardic, ofs=0, comp=comp, ops=ops)
     return value
-    

--- a/exfor_parserpy/utils/convenience.py
+++ b/exfor_parserpy/utils/convenience.py
@@ -9,22 +9,27 @@
 #
 ############################################################
 
+
 def apply_factor(data, fact):
     if isinstance(data, list):
-        newdata = [d*fact if d is not None else None for d in data]
+        newdata = [d * fact if d is not None else None for d in data]
     else:
         d = data
-        newdata = d*fact if d is not None else None
+        newdata = d * fact if d is not None else None
     return newdata
+
 
 def is_dic(obj):
     return isinstance(obj, dict)
 
+
 def is_list(obj):
     return isinstance(obj, list)
 
+
 def is_str(obj):
     return isinstance(obj, str)
+
 
 def is_subent_id(string):
     if not is_str(string) and len(string) != 8:
@@ -36,12 +41,14 @@ def is_subent_id(string):
             return False
     return True
 
+
 def is_subentry(dic, key=None):
     if key is not None and not is_subent_id(key):
         return False
-    if 'BIB' not in dic:
+    if "BIB" not in dic:
         return False
     return True
+
 
 def contains_pointers(dic):
     for k in dic:
@@ -53,26 +60,28 @@ def contains_pointers(dic):
             return False
     return True
 
+
 def has_common_block(dic):
-    if 'COMMON' in dic:
-        d = dic['COMMON']
-        if 'DATA' in d and 'UNIT' in d:
+    if "COMMON" in dic:
+        d = dic["COMMON"]
+        if "DATA" in d and "UNIT" in d:
             return True
     return False
 
+
 def has_data_block(dic):
-    if 'DATA' in dic:
-        d = dic['DATA']
-        if 'DATA' in d and 'UNIT' in d:
+    if "DATA" in dic:
+        d = dic["DATA"]
+        if "DATA" in d and "UNIT" in d:
             return True
         else:
             return False
 
+
 def count_points_in_datablock(datablock):
     length = -1
-    errmsg = ('Not all lists have the same length ' +
-              'in the DATA block')
-    for k, arr in datablock['DATA'].items():
+    errmsg = "Not all lists have the same length " + "in the DATA block"
+    for k, arr in datablock["DATA"].items():
         if is_dic(arr):
             # we deal with a pointer
             for p, arr2 in arr.items():
@@ -87,10 +96,10 @@ def count_points_in_datablock(datablock):
             length = curlength
     return length
 
+
 def merge_common_into_datablock(datablock, commonblock):
     numpoints = count_points_in_datablock(datablock)
-    for curkey, curitem in commonblock['UNIT'].items():
-        datablock['UNIT'][curkey] = curitem
-    for curkey, curval in commonblock['DATA'].items():
-        datablock['DATA'][curkey] = [curval for i in range(numpoints)]
-
+    for curkey, curitem in commonblock["UNIT"].items():
+        datablock["UNIT"][curkey] = curitem
+    for curkey, curval in commonblock["DATA"].items():
+        datablock["DATA"][curkey] = [curval for i in range(numpoints)]

--- a/exfor_parserpy/utils/custom_iterators.py
+++ b/exfor_parserpy/utils/custom_iterators.py
@@ -10,6 +10,7 @@
 
 from .convenience import is_dic
 
+
 def exfor_iterator(exfor_dic):
     """Traverse all subdictionaries bottom-up."""
     if is_dic(exfor_dic):
@@ -18,6 +19,7 @@ def exfor_iterator(exfor_dic):
                 yield from exfor_iterator(item)
         yield exfor_dic
 
+
 def exfor_iterator2(exfor_dic, key=None):
     """Traverse all subdictionaries bottom-up."""
     if is_dic(exfor_dic):
@@ -25,6 +27,7 @@ def exfor_iterator2(exfor_dic, key=None):
             if is_dic(item):
                 yield from exfor_iterator2(item, curkey)
         yield key, exfor_dic
+
 
 def exfor_iterator3(exfor_dic, key=None, parent=None, filterfun=None):
     """Traverse all subdictionaries bottom-up."""
@@ -39,10 +42,10 @@ def exfor_iterator3(exfor_dic, key=None, parent=None, filterfun=None):
         # even if filterfun evaluates to True
         yield key, exfor_dic, parent
 
+
 def search_for_field(dic, fieldname):
     """Find value of field by recursion."""
     for curdic in exfor_iterator(dic):
         if fieldname in curdic:
             return curdic[fieldname]
     return None
-

--- a/exfor_parserpy/utils/fortran_utils.py
+++ b/exfor_parserpy/utils/fortran_utils.py
@@ -8,13 +8,14 @@
 #
 ############################################################
 def fortstr2float(valstr, blank=None):
-    valstr = valstr.replace(' ','')
+    valstr = valstr.replace(" ", "")
     digitchars = (str(i) for i in range(10))
     for i, c in enumerate(valstr):
-        if i>0 and (c == '+' or c == '-'):
-            if valstr[i-1] in digitchars:
-                return float(valstr[:i] + 'E' + valstr[i:])
+        if i > 0 and (c == "+" or c == "-"):
+            if valstr[i - 1] in digitchars:
+                return float(valstr[:i] + "E" + valstr[i:])
     return float(valstr)
+
 
 def float2fortstr(val, width=11):
     av = abs(val)
@@ -27,34 +28,36 @@ def float2fortstr(val, width=11):
     else:
         nexp = 3
     ndec = width - nexp - 4
-    fmtstr = ('{:.' + str(ndec) + 'E}')
+    fmtstr = "{:." + str(ndec) + "E}"
     ss = fmtstr.format(val)
-    mantissa, exp = ss.split('E')
-    expsign = '+'
-    if exp[0] in ('-','+'):
+    mantissa, exp = ss.split("E")
+    expsign = "+"
+    if exp[0] in ("-", "+"):
         expsign = exp[0]
         exp = exp[1:]
-    exp = exp[:-1].lstrip('0') + exp[-1]
+    exp = exp[:-1].lstrip("0") + exp[-1]
     numstr = mantissa + expsign + exp
     numstr = numstr.rjust(width)
     assert len(numstr) == width
     return numstr
 
+
 def read_fort_floats(line, n=6, w=11, blank=None):
     assert isinstance(line, str)
     vals = []
-    for i in range(0, n*w, w):
-        if line[i:i+w] == ' '*w:
+    for i in range(0, n * w, w):
+        if line[i : i + w] == " " * w:
             if blank is None:
-                raise ValueError('blank encountered but blank=None')
+                raise ValueError("blank encountered but blank=None")
             else:
                 vals.append(blank)
         else:
-            vals.append(fortstr2float(line[i:i+w]))
+            vals.append(fortstr2float(line[i : i + w]))
     return vals
 
+
 def write_fort_floats(vals, w=11):
-    line = ''
+    line = ""
     for i, v in enumerate(vals):
         line += float2fortstr(v, w)
     return line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.8"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
+pre-commit = "^2.19.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Hi

In this merge request I introduce the `pre-commit` package as a dev dependency and I also add a minimal configuration file `.pre-commit-config.yaml` for it.

To use the `pre-commit` package, run `poetry install` to install it (you might have to delete your poetry.lock file first) and then run `pre-commit install` once, for it to hook into gits pre-commit mechanism.

From then on, all pre-commit hooks are executed before a commit can be made, if any hook fails, the commit is aborted and you have to fix (or add the reformatted code in case of black) what is criticized by the hook.

To apply all hooks to the whole codebase at once, `pre-commit run --all-files` can be executed, which is the reason for the many code changes in this merge request, although only the `pre-commit` package and its config were added.

There are many more hooks available (https://pre-commit.com/hooks.html) but I only added a minimal useful selection of them:

 - [black](https://github.com/psf/black)
 This is an autoformatter which offers very little configuration options on purpose to settle any discussion about formatting instantly.
 - trailing-whitespace
 All trailing whitespace characters are automatically removed
 - check-added-large-files
 Prevents adding large files (>500kB by default) to the repository
 - [mypy](https://github.com/python/mypy)
 Offers static type checking if type hints are introduced in the future. Although this is not very useful without type hints, it is also not in the way if they aren't used.

Although some pre-commit hooks and especially autoformatters are an acquired taste, they very much help with holding up a certain coding standard.