### PR TITLE
Add support for last modification timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,203 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.
@@ -186,7 +186,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/exfor_parserpy/exfor_parser.py
+++ b/exfor_parserpy/exfor_parser.py
@@ -197,6 +197,7 @@ def parse_subentry(lines, ofs=0, auxinfo=None, parse_opts=None):
     auxinfo["subentryid"] = read_str_field(lines[ofs], 1).strip()
     datadic["__entryid"] = auxinfo["entryid"]
     datadic["__subentid"] = auxinfo["subentryid"]
+    datadic["__lastmodified"] = read_str_field(lines[ofs], 2, 1).strip()
     ofs += 1
     while ofs < len(lines) and read_str_field(lines[ofs], 0) != "ENDSUBENT":
         curfield = read_str_field(lines[ofs], 0)
@@ -226,6 +227,9 @@ def output_subentry(datadic, ofs=0, auxinfo=None):
     lines = []
     subent_line = write_str_field("", 0, "SUBENT")
     subent_line = write_str_field(subent_line, 1, datadic["__subentid"], align="right")
+    subent_line = write_str_field(
+        subent_line, 2, datadic["__lastmodified"], align="right"
+    )
     lines.append(subent_line)
     ofs += 1
     if "BIB" in datadic:
@@ -256,6 +260,7 @@ def parse_entry(lines, ofs=0, auxinfo=None, parse_opts=None):
     auxinfo["entryid"] = read_str_field(lines[ofs], 1).strip()
     ofs += 1
     datadic = {}
+    datadic["__lastmodified"] = read_str_field(lines[ofs], 2, 1).strip()
     while ofs < len(lines) and read_str_field(lines[ofs], 0) != "ENDENTRY":
         if read_str_field(lines[ofs], 0) == "SUBENT":
             subentid = read_str_field(lines[ofs], 1).strip()
@@ -278,12 +283,16 @@ def output_entry(datadic, ofs=0, auxinfo=None):
     first_subentid = search_for_field(datadic, "__subentid")
     if not first_subentid:
         raise IndexError("No subentry identification number found")
+    last_modified = search_for_field(datadic, "__lastmodified")
     entryid = first_subentid[:5]
     entry_line = write_str_field("", 0, "ENTRY")
     entry_line = write_str_field(entry_line, 1, entryid, align="right")
+    entry_line = write_str_field(entry_line, 2, last_modified, align="right")
     lines.append(entry_line)
     ofs += 1
     for cursubent, curdic in datadic.items():
+        if not isinstance(curdic, dict):
+            continue
         curlines, ofs = output_subentry(curdic, ofs)
         lines.extend(curlines)
     lines.append(write_str_field("", 0, "ENDENTRY"))

--- a/exfor_parserpy/exfor_parser.py
+++ b/exfor_parserpy/exfor_parser.py
@@ -165,7 +165,7 @@ def output_common_or_data(datadic, ofs=0, what="common"):
     elif what == "data":
         curdic = datadic["DATA"]
         # get a column of the DATA section table
-        # to determine the numbe of rows
+        # to determine the number of rows
         while isinstance(curdic, dict):
             for key, cont in curdic.items():
                 curdic = cont
@@ -252,7 +252,6 @@ def output_subentry(datadic, ofs=0, auxinfo=None):
 
 
 def parse_entry(lines, ofs=0, auxinfo=None, parse_opts=None):
-    datadic = {"subentries": []}
     if read_str_field(lines[ofs], 0) != "ENTRY":
         raise TypeError("not an ENTRY block")
     if auxinfo is None:

--- a/exfor_parserpy/exfor_parser.py
+++ b/exfor_parserpy/exfor_parser.py
@@ -257,9 +257,9 @@ def parse_entry(lines, ofs=0, auxinfo=None, parse_opts=None):
     if auxinfo is None:
         auxinfo = {}
     auxinfo["entryid"] = read_str_field(lines[ofs], 1).strip()
-    ofs += 1
     datadic = {}
     datadic["__lastmodified"] = read_str_field(lines[ofs], 2, 1).strip()
+    ofs += 1
     while ofs < len(lines) and read_str_field(lines[ofs], 0) != "ENDENTRY":
         if read_str_field(lines[ofs], 0) == "SUBENT":
             subentid = read_str_field(lines[ofs], 1).strip()

--- a/exfor_parserpy/exfor_parser.py
+++ b/exfor_parserpy/exfor_parser.py
@@ -282,7 +282,8 @@ def output_entry(datadic, ofs=0, auxinfo=None):
     first_subentid = search_for_field(datadic, "__subentid")
     if not first_subentid:
         raise IndexError("No subentry identification number found")
-    last_modified = search_for_field(datadic, "__lastmodified")
+    if not (last_modified := datadic.get("__lastmodified", None)):
+        raise KeyError("No last modification value found")
     entryid = first_subentid[:5]
     entry_line = write_str_field("", 0, "ENTRY")
     entry_line = write_str_field(entry_line, 1, entryid, align="right")


### PR DESCRIPTION
Adding support for the header last modification field (N2) when reading and writing exfor files. The modification timestamps is handled similar to the entry and subentry ids via the `__lastmodification` dictionary key on entry as well as subentry level

Further improvements
- Adding of .gitignore file to avoid accidental addition of non-package files
- Fixing of minor typos / code cleanup